### PR TITLE
Vagrant improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,13 +128,12 @@ On Windows make sure VAGRANT_HOME is alwasy set.
 set VAGRANT_HOME=C:\HashiCorp\Vagrant\home
 ```
 
-Since host-manager is used to update */etc/hosts* on each guest node and host node, the Vagrantfile should be updated.
-
 When running on Linux, and if a DNS server is not used, it is required to tell vagrant to update the host's */etc/hosts* to contain all guest's IPs. In Vagrantfile do the following update:
 ```
 -  config.hostmanager.manage_host = false
 +  config.hostmanager.manage_host = true
 ```
+
 On Windows such option does not have effect because the [Ubuntu environment](#windows) has its own */etc/hosts*.
 At the bash console edit */etc/hosts* with IPs obtains through.
 ```
@@ -144,8 +143,10 @@ vagrant ssh-config emma0
 ssh -i .vagrant/machines/emma0/virtualbox/private_key ubuntu@127.0.0.1 -p <emma0_port> "cat /etc/hosts"
 ```
 
-
-To update the guest nodes */etc/hosts*, create and start the VMs, read the steps described in [#14](../../issues/14#issuecomment-285029919).
+On the first *vagrant up* guest machines */etc/hosts* will be updated. It is possible to request a new update by simply do:
+```
+vagrant hostmanager
+```
 
 To halt all VMs
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,10 +51,10 @@ Vagrant.configure(2) do |config|
   config.hostmanager.ignore_private_ip = true
   config.hostmanager.ip_resolver = proc do |machine|
     result = ""
-    machine.communicate.execute("ifconfig enp0s8") do |type, data|
+    machine.communicate.execute("hostname -I") do |type, data|
         result << data if type == :stdout
     end
-    (ip = /inet addr:(\d+\.\d+\.\d+\.\d+)/.match(result)) && ip[1]
+    ip = result.split.last
   end
   config.vm.provision :hostmanager
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -43,8 +43,9 @@ Vagrant.configure(2) do |config|
     apt-get install -y python-dev
   SHELL
 
-  config.hostmanager.enabled = true
-  config.hostmanager.manage_guest = false
+  #Hostmanager should be set to false so it runs after provisioning
+  config.hostmanager.enabled = false
+  config.hostmanager.manage_guest = true
   config.hostmanager.manage_host = false
   config.hostmanager.include_offline = false
   config.hostmanager.ignore_private_ip = true
@@ -55,4 +56,6 @@ Vagrant.configure(2) do |config|
     end
     (ip = /inet addr:(\d+\.\d+\.\d+\.\d+)/.match(result)) && ip[1]
   end
+  config.vm.provision :hostmanager
+
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,19 +1,63 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+module OS
+    def OS.windows?
+        (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
+    end
+
+    def OS.mac?
+        (/darwin/ =~ RUBY_PLATFORM) != nil
+    end
+
+    def OS.unix?
+        !OS.windows?
+    end
+
+    def OS.linux?
+        OS.unix? and not OS.mac?
+    end
+end
+
+is_windows_host = "#{OS.windows?}"
+puts "is_windows_host: #{OS.windows?}"
+if OS.windows?
+    puts "Vagrant launched from windows."
+elsif OS.mac?
+    puts "Vagrant launched from mac."
+elsif OS.unix?
+    puts "Vagrant launched from unix."
+elsif OS.linux?
+    puts "Vagrant launched from linux."
+else
+    puts "Vagrant launched from unknown platform."
+end
 
 Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/xenial64"
   config.vm.network "public_network", bridge: "enp2s0"
+  #Check if there is a new update for the box
+  config.vm.box_check_update = true
   config.vbguest.auto_update = true
-  config.vm.synced_folder ".", "/vagrant", type: "virtualbox", disabled: false
+  vbox = VagrantPlugins::ProviderVirtualBox::Driver::Meta.new
+  vbox_version = vbox.version
 
+  if Vagrant::VERSION =~ /1.9.[0-9]/ && vbox_version =~ /5.1.[0-9]/
+    puts "VB version is: %s" % [vbox_version]
+    puts "Vagrant version is: %s" % [Vagrant::VERSION]
+    puts "Disable synced_folder"
+    config.vm.synced_folder ".", "/vagrant", type: "virtualbox", disabled: true
+  else
+    puts "VB version is: %s" % [vbox_version]
+    puts "Vagrant version is: %s" % [Vagrant::VERSION]
+    config.vm.synced_folder ".", "/vagrant", type: "virtualbox", disabled: false
+  end
 
   (0..2).each do |i|
-    config.vm.define "emma#{i}" do |node|
-      node.vm.hostname = "emma#{i}.#{ENV['EMMA_DOMAIN']}"
+    config.vm.define "#{ENV['HOST_NAME']}#{i}" do |node|
+      node.vm.hostname = "#{ENV['HOST_NAME']}#{i}.#{ENV['HOST_DOMAIN']}"
       # GlusterFS storage disk
       node.persistent_storage.enabled = true
-      node.persistent_storage.location = "emma#{i}-data.vdi"
+      node.persistent_storage.location = "#{ENV['HOST_NAME']}#{i}-data.vdi"
       node.persistent_storage.size = 20000
       node.persistent_storage.mountname = 'data'
       node.persistent_storage.filesystem = 'xfs'
@@ -33,10 +77,21 @@ Vagrant.configure(2) do |config|
     s.inline = "sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile"
   end
 
+  if Vagrant::VERSION =~ /1.9.[0-9]/ && vbox_version =~ /5.1.[0-9]/
+    puts "Copy ssh keys by hand."
+    config.vm.provision "file", source: "./#{ENV['HOST_NAME']}.key", destination: "/tmp/#{ENV['HOST_NAME']}.key"
+    config.vm.provision "file", source: "./#{ENV['HOST_NAME']}.key.pub", destination: "/tmp/#{ENV['HOST_NAME']}.key.pub"
+    config.vm.provision "shell", inline: <<-SHELL
+      mkdir -p /vagrant
+      cp /tmp/#{ENV['HOST_NAME']}.key /vagrant/
+      cp /tmp/#{ENV['HOST_NAME']}.key.pub /vagrant/
+    SHELL
+  end
+
   config.vm.provision "shell", inline: <<-SHELL
     mkdir -p /root/.ssh
-    cp /vagrant/emma.key /root/.ssh/id_rsa
-    cp /vagrant/emma.key.pub /root/.ssh/id_rsa.pub
+    cp /vagrant/#{ENV['HOST_NAME']}.key /root/.ssh/id_rsa
+    cp /vagrant/#{ENV['HOST_NAME']}.key.pub /root/.ssh/id_rsa.pub
     cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
     chmod -R 600 /root/.ssh
     apt-get update
@@ -46,7 +101,11 @@ Vagrant.configure(2) do |config|
   #Hostmanager should be set to false so it runs after provisioning
   config.hostmanager.enabled = false
   config.hostmanager.manage_guest = true
-  config.hostmanager.manage_host = false
+  if OS.windows?
+    config.hostmanager.manage_host = false
+  else
+    config.hostmanager.manage_host = true
+  end
   config.hostmanager.include_offline = false
   config.hostmanager.ignore_private_ip = true
   config.hostmanager.ip_resolver = proc do |machine|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,8 +4,8 @@
 Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/xenial64"
   config.vm.network "public_network", bridge: "enp2s0"
-  config.vbguest.auto_update = false
-  config.vm.synced_folder ".", "/vagrant", disabled: false
+  config.vbguest.auto_update = true
+  config.vm.synced_folder ".", "/vagrant", type: "virtualbox", disabled: false
 
 
   (0..2).each do |i|

--- a/env_linux.sh.template
+++ b/env_linux.sh.template
@@ -1,0 +1,3 @@
+#!/bin/bash
+export HOST_NAME=<name>
+export HOST_DOMAIN=<domain>

--- a/env_windows.cmd.template
+++ b/env_windows.cmd.template
@@ -1,0 +1,6 @@
+@ECHO OFF
+
+set HOST_NAME=<name>
+set HOST_DOMAIN=<domains>
+#By default Vagrant is installed at C:\HashiCorp\Vagrant
+set VAGRANT_HOME=<vagrant_home>


### PR DESCRIPTION
It solves the issue reported in 
https://github.com/nlesc-sherlock/emma/issues/14

Not hostmanager is run as a provision, so it only happens once all nodes are up and running.
vagrant hostmanager can also be called to update /etc/host on all guest machines

Furthermore, no dependency on the interface name to get the machine IP.