### PR TITLE
Hadoop format

### DIFF
--- a/roles/hadoop/tasks/main.yml
+++ b/roles/hadoop/tasks/main.yml
@@ -96,9 +96,31 @@
 - name: Copy hadoop-hdfs.systemd
   template: src=hadoop-hdfs.systemd.j2 dest=/etc/systemd/system/hadoop-hdfs.service
 
+- name: Check if namenode exists
+  stat:
+    path: "{{ hadoop_dir }}/namenode"
+  register: stat_result
+
+- name: Delete namenode if it exists
+  file:
+   state: absent
+   path: "{{ hadoop_dir }}/namenode/"
+  when: stat_result.stat.exists == True
+
 - name: Ensure Hadoop namenode directory exists
   file: path="{{ hadoop_dir }}/namenode" state=directory owner={{ hadoop_user }} group={{ hadoop_user_groups[0] }} mode=700
   when: inventory_hostname in groups['hadoop-namenode']
+
+- name: Check if datanode exists
+  stat:
+    path: "{{ hadoop_dir }}/datanode"
+  register: stat_result
+
+- name: Delete datanode if it exists
+  file:
+   state: absent
+   path: "{{ hadoop_dir }}/datanode/"
+  when: stat_result.stat.exists == True
 
 - name: Ensure Hadoop datanode directory exists
   file: path="{{ hadoop_dir }}/datanode" state=directory owner={{ hadoop_user }} group={{ hadoop_user_groups[0] }} mode=700

--- a/roles/hadoop/vars/main.yml
+++ b/roles/hadoop/vars/main.yml
@@ -9,6 +9,6 @@ hadoop_usr_dir: "/usr/lib/hadoop"   #this is the symlink to the extracted/instal
 hadoop_lib_dir: "/var/lib/hadoop"
 hadoop_log_dir: "/var/log/hadoop"
 hadoop_run_dir: "/run/hadoop"
-hadoop_users: [ hadoop ]           # the name of the (OS)user created for hadoop
+hadoop_users: [ hadoop, spark, ubuntu ]           # the name of the (OS)user created for hadoop
 hadoop_user: "{{ hadoop_users[0] }}"
 hadoop_user_groups: [ users ]         # Optional list of (OS)groups the new hadoop user should belong to

--- a/roles/jupyterhub/files/jupyterhub.systemd
+++ b/roles/jupyterhub/files/jupyterhub.systemd
@@ -4,9 +4,7 @@ After=syslog.target network.target
 
 [Service]
 User=root
-Type=forking
 ExecStart=/usr/local/bin/jupyterhub -f /etc/jupyterhub/jupyterhub_config.py
-KillMode=process
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/minio/README.md
+++ b/roles/minio/README.md
@@ -41,3 +41,8 @@ s3cmd  ls s3://files
 
 s3cmd get s3://files/sonnets.txt romulo.txt
 ```
+
+To upload data to a sub-directory follow this example:
+```
+cd <root_dir>/<sub_dir> ; for f in `ls *`; do s3cmd put $f s3://<root_dir>/<sub_dir>/$f; done
+```

--- a/roles/spark/templates/hive-site.xml.j2
+++ b/roles/spark/templates/hive-site.xml.j2
@@ -11,7 +11,7 @@
   </property>
   <property>
     <name>hive.metastore.warehouse.dir</name>
-    <value>{{ spark_dir }}/</value>
+    <value>file://{{ spark_dir }}/</value>
     <description>location of default database for the warehouse</description>
   </property>
 </configuration>

--- a/roles/spark/tests/sonnets.sc
+++ b/roles/spark/tests/sonnets.sc
@@ -1,7 +1,7 @@
 val sonnets = sc.textFile("s3a://files/sonnets.txt")
 val counts = sonnets.flatMap(line => line.split(" ")).map(word => (word, 1)).reduceByKey(_ + _)
 
-counts.saveAsTextFile("hdfs://user/spark/files/output")
+counts.saveAsTextFile("hdfs:///user/ubuntu/files/output")
 
 #At the moment it is not possible to save output to S3
 #counts.saveAsTextFile("s3a://files/output")


### PR DESCRIPTION
This pull request makes sure data and name node directories are deleted before we format namenode. Like this we avoid issues and corruption of catalogs.

It also fixes other issues we found to start spark-shell, read from Minio, run query and save result to HDFS.