### PR TITLE
Spark work dir

### DIFF
--- a/roles/spark/tasks/main.yml
+++ b/roles/spark/tasks/main.yml
@@ -41,7 +41,7 @@
         state=directory
   tags: ["config"]
 
-- name: Ensure Spark log and run directories exist
+- name: Ensure Spark log, run, and work directories exist
   file: path="{{ item }}"
         owner={{ spark_user }}
         group={{ spark_user_groups[0] }}
@@ -50,6 +50,7 @@
   with_items:
     - "{{ spark_log_dir }}"
     - "{{ spark_run_dir }}"
+    - "{{ spark_work_dir }}"
 
 - name: Download Spark distribution
   get_url: url="{{ spark_mirror }}/spark-{{ spark_version }}-bin-without-hadoop.tgz"

--- a/roles/spark/templates/spark-env.sh.j2
+++ b/roles/spark/templates/spark-env.sh.j2
@@ -41,7 +41,9 @@ export SPARK_WORKER_MEMORY="{{ spark_worker_memory }}"
 # - SPARK_WORKER_PORT / SPARK_WORKER_WEBUI_PORT, to use non-default ports for the worker
 # - SPARK_WORKER_INSTANCES, to set the number of worker processes per node
 # - SPARK_WORKER_DIR, to set the working directory of worker processes
+export SPARK_WORKER_DIR="{{ spark_work_dir }}"
 # - SPARK_WORKER_OPTS, to set config properties only for the worker (e.g. "-Dx=y")
+export SPARK_WORKER_OPTS="-Dspark.worker.cleanup.enabled=true -Dspark.worker.cleanup.appDataTtl=172800"
 # - SPARK_HISTORY_OPTS, to set config properties only for the history server (e.g. "-Dx=y")
 # - SPARK_DAEMON_JAVA_OPTS, to set config properties for all daemons (e.g. "-Dx=y")
 # - SPARK_PUBLIC_DNS, to set the public dns name of the master or workers

--- a/vars/spark_vars.yml.template
+++ b/vars/spark_vars.yml.template
@@ -17,6 +17,9 @@ spark_usr_dir: "/usr/lib/spark"   #this is the symlink to the extracted/installe
 #Define the location of the logs
 spark_log_dir: "/data/local/spark/log/spark"
 
+#Define the location of work dir
+spark_work_dir: "/data/local/spark/work"
+
 spark_dir: "/data/local/spark"
 spark_run_dir: "/run/spark"
 spark_env_extras: {}


### PR DESCRIPTION
After having Spark working for 7 days non-stop, we have reached some limits, apps and logs consumed too much disk space.

We were able to run Kmeans up to 2000 clusters with 35 iterations each run, so it shows that things are running. To avoid running out of space I decided to move the Spark's **work** directory to /data/local/ and also make sure the logs are cleaned every 48 hours.