### PR TITLE
Spark modules is for extensions to Spark for which we only download j…

### DIFF
--- a/roles/spark/defaults/main.yml
+++ b/roles/spark/defaults/main.yml
@@ -49,6 +49,7 @@ gc_debug: "" #"-XX:+PrintFlagsFinal -XX:+PrintReferenceGC -verbose:gc -XX:+Print
 gc_type: "+UseG1GC" #Or +UseParallelGC
 spark_debug_mode: false
 
+scispark_dir: "/data/local/scispark"
 magellan_groupId: "harsha2010"
 magellan_artifactId: "magellan"
 magellan_version: "1.0.5-s_2.11"

--- a/roles/spark/defaults/main.yml
+++ b/roles/spark/defaults/main.yml
@@ -31,6 +31,7 @@ spark_driver_maxResultSize: 1g
 spark_dynamicAllocation_initialExecutors: 1
 spark_dynamicAllocation_maxExecutors: 2
 spark_broadcast_blockSize: 20m
+spark_task_cpus: 2
 
 joda_time_version: "2.9.4"
 aws_version: "1.10.6"

--- a/roles/spark/defaults/main.yml
+++ b/roles/spark/defaults/main.yml
@@ -31,7 +31,6 @@ spark_driver_maxResultSize: 1g
 spark_dynamicAllocation_initialExecutors: 1
 spark_dynamicAllocation_maxExecutors: 2
 spark_broadcast_blockSize: 20m
-spark_task_cpus: 2
 
 joda_time_version: "2.9.4"
 aws_version: "1.10.6"
@@ -49,4 +48,7 @@ gc_debug: "" #"-XX:+PrintFlagsFinal -XX:+PrintReferenceGC -verbose:gc -XX:+Print
 gc_type: "+UseG1GC" #Or +UseParallelGC
 spark_debug_mode: false
 
-scispark_dir: "/data/local/scispark"
+magellan_groupId: "harsha2010"
+magellan_artifactId: "magellan"
+magellan_version: "1.0.5-s_2.11"
+magellan_maven_url: "https://dl.bintray.com/spark-packages/maven/"

--- a/roles/spark/tasks/main.yml
+++ b/roles/spark/tasks/main.yml
@@ -298,3 +298,8 @@
 
 - name: Gradle install dependencies
   shell: gradle downloadDependencies
+
+- name: Install Spark's modules
+  include: modules.yml
+  tags:
+    - spark_modules

--- a/roles/spark/tasks/modules.yml
+++ b/roles/spark/tasks/modules.yml
@@ -1,0 +1,7 @@
+---
+#Get Magellan
+- name: Get Magellan
+  get_url: url="https://dl.bintray.com/spark-packages/maven/{{ magellan_groupId }}/{{ magellan_artifactId }}/{{ magellan_version }}/{{ magellan_artifactId }}-{{ magellan_version }}.jar"
+           dest="{{ spark_usr_dir }}/jars/magellan-{{ magellan_version }}.jar"
+  tags:
+    - magellan

--- a/vars/spark_vars.yml.template
+++ b/vars/spark_vars.yml.template
@@ -62,6 +62,7 @@ spark_driver_maxResultSize: 2g
 spark_dynamicAllocation_initialExecutors: 1
 spark_dynamicAllocation_maxExecutors: 2
 spark_broadcast_blockSize: 20m
+spark_task_cpus: 2
 
 magellan_groupId: "harsha2010"
 magellan_artifactId: "magellan"

--- a/vars/spark_vars.yml.template
+++ b/vars/spark_vars.yml.template
@@ -62,4 +62,8 @@ spark_driver_maxResultSize: 2g
 spark_dynamicAllocation_initialExecutors: 1
 spark_dynamicAllocation_maxExecutors: 2
 spark_broadcast_blockSize: 20m
-spark_task_cpus: 2
+
+magellan_groupId: "harsha2010"
+magellan_artifactId: "magellan"
+magellan_version: "1.0.5-s_2.11"
+magellan_maven_url: "https://dl.bintray.com/spark-packages/maven/"


### PR DESCRIPTION
…ars. When the system does not need to be installed from scratch and can't be run in standalone mode, we simply add it as a Spark module. Add Magellean which is an module of Spark for spatial queries.