### PR TITLE
Mirrors and package

### DIFF
--- a/roles/jupyterhub/tasks/main.yml
+++ b/roles/jupyterhub/tasks/main.yml
@@ -2,6 +2,11 @@
 - name: Ensure Jupyter source directory exists
   file: path="{{ jupyterhub_src_dir }}" state=directory group=users mode=g+rw
 
+- name: Add an Apt signing key for the latest nodejs
+  apt_key:
+    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+    state: present
+
 - name: Deps 4 JupyterHub notebook
   apt: name={{ item }}
   with_items:

--- a/roles/jupyterhub/tasks/toree.yml
+++ b/roles/jupyterhub/tasks/toree.yml
@@ -5,7 +5,7 @@
 # https://medium.com/@faizanahemad/machine-learning-with-jupyter-using-scala-spark-and-python-the-setup-62d05b0c7f56
 
 - name: Toree (Spark Jupyter) installation
-  pip: executable=pip3 name=https://dist.apache.org/repos/dist/dev/incubator/toree/0.2.0-incubating-rc1/toree-pip/toree-0.2.0.tar.gz
+  pip: executable=pip3 name={{ toree_download_url }}
 
 - name: Toree to Jupyter
   shell: jupyter toree install --python_exec='python3.5' --spark_home='{{ spark_usr_dir }}' --spark_opts='--master=spark://{{ groups['spark-master'][0] }}:7077' --interpreters=Scala,PySpark,SparkR,SQL creates=/usr/local/share/jupyter/kernels/apache_toree_scala

--- a/roles/pdal/tasks/main.yml
+++ b/roles/pdal/tasks/main.yml
@@ -34,7 +34,7 @@
 #Install Lastools
 - name: Extract LAStools
   unarchive:
-    src="http://lastools.org/download/laszip.zip"
+    src="{{ lastools_download_url }}"
     dest="{{ emma_modules_dir }}"
     copy=no
     creates="{{ emma_modules_dir }}/LAStools"

--- a/vars/common_vars.yml.template
+++ b/vars/common_vars.yml.template
@@ -36,6 +36,7 @@ system_packages:
   - cmake
   - linux-tools-virtual
   - software-properties-common
+  - libffi-dev
 
 #Create swap space
 create_swap_space: false

--- a/vars/jupyterhub_vars.yml.template
+++ b/vars/jupyterhub_vars.yml.template
@@ -1,4 +1,5 @@
 ---
 cran_url: https://cran.uni-muenster.de
+toree_download_url: https://dist.apache.org/repos/dist/dev/incubator/toree/0.2.0-incubating-rc1/toree-pip/toree-0.2.0.tar.gz
 jupyterhub_src_dir: /data/local/jupyterhub
 jupyterhub_modules_dir: /data/local/jupyterhub/modules

--- a/vars/pdal_vars.yml.template
+++ b/vars/pdal_vars.yml.template
@@ -1,1 +1,2 @@
 ---
+lastools_download_url: "http://www.cs.unc.edu/~isenburg/lastools/download/LAStools.zip"

--- a/vars/spark_vars.yml.template
+++ b/vars/spark_vars.yml.template
@@ -13,7 +13,7 @@ spark_prev_version: "2.1.1"
 spark_version: "2.1.1"
 
 #Define Spark mirror
-spark_mirror: "http://d3kbcqa49mib13.cloudfront.net"
+spark_mirror: "https://archive.apache.org/dist/spark/spark-{{ spark_version }}"
 
 #Define the location for the configuration dir for Spark (default value: /etc/spark)
 spark_conf_dir: "/etc/spark"


### PR DESCRIPTION
Some urls were hard coded and they shouldn't be.
I fix a mirror, now we use the general site to download.

One package was missing when we only install PDAL and Massive Potree Converter.